### PR TITLE
View placement school details

### DIFF
--- a/app/assets/sass/utilities/_overrides.scss
+++ b/app/assets/sass/utilities/_overrides.scss
@@ -2,3 +2,13 @@
   position: relative;
   top: -7px;
 }
+
+.govuk-service-navigation__wrapper {
+  flex-grow: 1;
+}
+
+.app-service-navigation__align-right {
+  @include govuk-media-query($from: tablet) {
+    margin-left: auto;
+  }
+}

--- a/app/controllers/placementSchool.js
+++ b/app/controllers/placementSchool.js
@@ -11,14 +11,16 @@ const {
 } = require('../helpers/gias')
 
 const {
-  PlacementSchool,
-  School,
-  Provider,
   AcademicYear,
-  SchoolType,
+  PlacementSchool,
+  Provider,
+  School,
+  SchoolAddress,
+  SchoolDetail,
+  SchoolEducationPhase,
   SchoolGroup,
   SchoolStatus,
-  SchoolEducationPhase,
+  SchoolType,
   Sequelize
 } = require('../models')
 
@@ -420,4 +422,34 @@ exports.removeAllFilters = (req, res) => {
 exports.removeKeywordSearch = (req, res) => {
   delete req.session.data.keywords
   res.redirect('/placement-schools')
+}
+
+/// ------------------------------------------------------------------------ ///
+/// Show placement school
+/// ------------------------------------------------------------------------ ///
+
+exports.placementSchoolDetails = async (req, res) => {
+  // Clear session provider data
+  delete req.session.data.keywords
+  delete req.session.data.filters
+  delete req.session.data.find
+
+  const { schoolId } = req.params
+
+  // Fetch the provider
+  const placementSchool = await School.findOne({
+    where: { id: schoolId },
+    include: [
+      { model: SchoolDetail, as: 'schoolDetail' },
+      { model: SchoolAddress, as: 'schoolAddress' },
+      { model: SchoolType, as: 'schoolType' },
+      { model: SchoolGroup, as: 'schoolGroup' },
+      { model: SchoolEducationPhase, as: 'schoolEducationPhase' },
+      { model: SchoolStatus, as: 'schoolStatus' }
+    ]
+  })
+
+  res.render('placement-schools/show', {
+    placementSchool
+   })
 }

--- a/app/migrations/20250717121700-create-school-detail.js
+++ b/app/migrations/20250717121700-create-school-detail.js
@@ -27,7 +27,7 @@ module.exports = {
       statutory_high_age: {
         type: Sequelize.INTEGER
       },
-      boarders_code: {
+      boarder_code: {
         type: Sequelize.STRING
       },
       nursery_provision_code: {

--- a/app/migrations/20250717121700-create-school-detail.js
+++ b/app/migrations/20250717121700-create-school-detail.js
@@ -33,7 +33,7 @@ module.exports = {
       nursery_provision_code: {
         type: Sequelize.STRING
       },
-      official_six_form_code: {
+      official_sixth_form_code: {
         type: Sequelize.STRING
       },
       gender_code: {

--- a/app/migrations/20250721123400-create-school-nursery-provision.js
+++ b/app/migrations/20250721123400-create-school-nursery-provision.js
@@ -1,6 +1,6 @@
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('school_nursery_provision', {
+    await queryInterface.createTable('school_nursery_provisions', {
       id: {
         type: Sequelize.UUID,
         defaultValue: Sequelize.UUIDV4,
@@ -48,6 +48,6 @@ module.exports = {
     })
   },
   async down(queryInterface, Sequelize) {
-    await queryInterface.dropTable('school_nursery_provision')
+    await queryInterface.dropTable('school_nursery_provisions')
   }
 }

--- a/app/migrations/20250721123600-create-school-sixth-form.js
+++ b/app/migrations/20250721123600-create-school-sixth-form.js
@@ -1,6 +1,6 @@
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.createTable('school_sixth_form', {
+    await queryInterface.createTable('school_sixth_forms', {
       id: {
         type: Sequelize.UUID,
         defaultValue: Sequelize.UUIDV4,
@@ -48,6 +48,6 @@ module.exports = {
     })
   },
   async down(queryInterface, Sequelize) {
-    await queryInterface.dropTable('school_sixth_form')
+    await queryInterface.dropTable('school_sixth_forms')
   }
 }

--- a/app/models/schoolAdmissionsPolicy
+++ b/app/models/schoolAdmissionsPolicy
@@ -1,0 +1,96 @@
+const { Model, DataTypes } = require('sequelize')
+
+module.exports = (sequelize) => {
+  class SchoolAdmissionsPolicy extends Model {
+    static associate(models) {
+      SchoolAdmissionsPolicy.hasMany(models.SchoolDetail, {
+        foreignKey: 'admissionsPolicyCode',
+        sourceKey: 'code',
+        as: 'schoolDetails'
+      })
+
+      SchoolAdmissionsPolicy.belongsTo(models.User, {
+        foreignKey: 'createdById',
+        as: 'createdByUser'
+      })
+
+      SchoolAdmissionsPolicy.belongsTo(models.User, {
+        foreignKey: 'updatedById',
+        as: 'updatedByUser'
+      })
+    }
+  }
+
+  SchoolAdmissionsPolicy.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      code:  {
+        type: DataTypes.STRING
+      },
+      name:  {
+        type: DataTypes.STRING
+      },
+      rank:  {
+        type: DataTypes.TINYINT
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at'
+      },
+      createdById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'created_by_id'
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'updated_at'
+      },
+      updatedById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
+      }
+    },
+    {
+      sequelize,
+      modelName: 'SchoolAdmissionsPolicy',
+      tableName: 'school_admissions_policies',
+      timestamps: true
+    }
+  )
+
+  // const createRevisionHook = require('../hooks/revisionHook')
+
+  // SchoolAdmissionsPolicy.addHook('afterCreate', (instance, options) =>
+  //   createRevisionHook({ revisionModelName: 'SchoolAdmissionsPolicyRevision', modelKey: 'schoolAdmissionsPolicy' })(instance, {
+  //     ...options,
+  //     hookName: 'afterCreate'
+  //   })
+  // )
+
+  // SchoolAdmissionsPolicy.addHook('afterUpdate', (instance, options) => {
+  //   const hookName = instance.deletedById !== null ? 'afterDestroy' : 'afterUpdate'
+  //   createRevisionHook({ revisionModelName: 'SchoolAdmissionsPolicyRevision', modelKey: 'schoolAdmissionsPolicy' })(instance, {
+  //     ...options,
+  //     hookName
+  //   })
+  // })
+
+  return SchoolAdmissionsPolicy
+}

--- a/app/models/schoolBoarder.js
+++ b/app/models/schoolBoarder.js
@@ -1,0 +1,96 @@
+const { Model, DataTypes } = require('sequelize')
+
+module.exports = (sequelize) => {
+  class SchoolBoarder extends Model {
+    static associate(models) {
+      SchoolBoarder.hasMany(models.SchoolDetail, {
+        foreignKey: 'boarderCode',
+        sourceKey: 'code',
+        as: 'schoolDetails'
+      })
+
+      SchoolBoarder.belongsTo(models.User, {
+        foreignKey: 'createdById',
+        as: 'createdByUser'
+      })
+
+      SchoolBoarder.belongsTo(models.User, {
+        foreignKey: 'updatedById',
+        as: 'updatedByUser'
+      })
+    }
+  }
+
+  SchoolBoarder.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      code:  {
+        type: DataTypes.STRING
+      },
+      name:  {
+        type: DataTypes.STRING
+      },
+      rank:  {
+        type: DataTypes.TINYINT
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at'
+      },
+      createdById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'created_by_id'
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'updated_at'
+      },
+      updatedById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
+      }
+    },
+    {
+      sequelize,
+      modelName: 'SchoolBoarder',
+      tableName: 'school_boarders',
+      timestamps: true
+    }
+  )
+
+  // const createRevisionHook = require('../hooks/revisionHook')
+
+  // SchoolBoarder.addHook('afterCreate', (instance, options) =>
+  //   createRevisionHook({ revisionModelName: 'SchoolBoarderRevision', modelKey: 'schoolBoarder' })(instance, {
+  //     ...options,
+  //     hookName: 'afterCreate'
+  //   })
+  // )
+
+  // SchoolBoarder.addHook('afterUpdate', (instance, options) => {
+  //   const hookName = instance.deletedById !== null ? 'afterDestroy' : 'afterUpdate'
+  //   createRevisionHook({ revisionModelName: 'SchoolBoarderRevision', modelKey: 'schoolBoarder' })(instance, {
+  //     ...options,
+  //     hookName
+  //   })
+  // })
+
+  return SchoolBoarder
+}

--- a/app/models/schoolDetail.js
+++ b/app/models/schoolDetail.js
@@ -49,17 +49,17 @@ module.exports = (sequelize) => {
         type: DataTypes.INTEGER,
         field: 'statutory_high_age'
       },
-      boardersCode:  {
+      boarderCode:  {
         type: DataTypes.STRING,
-        field: 'boarders_code'
+        field: 'boarder_code'
       },
       nurseryProvisionCode:  {
         type: DataTypes.STRING,
         field: 'nursery_provision_code'
       },
-      officialSixFormCode:  {
+      officialSixthFormCode:  {
         type: DataTypes.STRING,
-        field: 'official_six_form_code'
+        field: 'official_sixth_form_code'
       },
       genderCode:  {
         type: DataTypes.STRING,
@@ -103,7 +103,7 @@ module.exports = (sequelize) => {
       },
       parliamentaryConstituencyCode:  {
         type: DataTypes.STRING,
-        field: 'parliamentart_constituency_code'
+        field: 'parliamentary_constituency_code'
       },
       urbanRuralCode:  {
         type: DataTypes.STRING,

--- a/app/models/schoolGender.js
+++ b/app/models/schoolGender.js
@@ -1,0 +1,96 @@
+const { Model, DataTypes } = require('sequelize')
+
+module.exports = (sequelize) => {
+  class SchoolGender extends Model {
+    static associate(models) {
+      SchoolGender.hasMany(models.SchoolDetail, {
+        foreignKey: 'genderCode',
+        sourceKey: 'code',
+        as: 'schoolDetails'
+      })
+
+      SchoolGender.belongsTo(models.User, {
+        foreignKey: 'createdById',
+        as: 'createdByUser'
+      })
+
+      SchoolGender.belongsTo(models.User, {
+        foreignKey: 'updatedById',
+        as: 'updatedByUser'
+      })
+    }
+  }
+
+  SchoolGender.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      code:  {
+        type: DataTypes.STRING
+      },
+      name:  {
+        type: DataTypes.STRING
+      },
+      rank:  {
+        type: DataTypes.TINYINT
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at'
+      },
+      createdById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'created_by_id'
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'updated_at'
+      },
+      updatedById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
+      }
+    },
+    {
+      sequelize,
+      modelName: 'SchoolGender',
+      tableName: 'school_genders',
+      timestamps: true
+    }
+  )
+
+  // const createRevisionHook = require('../hooks/revisionHook')
+
+  // SchoolGender.addHook('afterCreate', (instance, options) =>
+  //   createRevisionHook({ revisionModelName: 'SchoolGenderRevision', modelKey: 'schoolGender' })(instance, {
+  //     ...options,
+  //     hookName: 'afterCreate'
+  //   })
+  // )
+
+  // SchoolGender.addHook('afterUpdate', (instance, options) => {
+  //   const hookName = instance.deletedById !== null ? 'afterDestroy' : 'afterUpdate'
+  //   createRevisionHook({ revisionModelName: 'SchoolGenderRevision', modelKey: 'schoolGender' })(instance, {
+  //     ...options,
+  //     hookName
+  //   })
+  // })
+
+  return SchoolGender
+}

--- a/app/models/schoolNurseryProvision.js
+++ b/app/models/schoolNurseryProvision.js
@@ -1,0 +1,96 @@
+const { Model, DataTypes } = require('sequelize')
+
+module.exports = (sequelize) => {
+  class SchoolNurseryProvision extends Model {
+    static associate(models) {
+      SchoolNurseryProvision.hasMany(models.SchoolDetail, {
+        foreignKey: 'nurseryProvisionCode',
+        sourceKey: 'code',
+        as: 'schoolDetails'
+      })
+
+      SchoolNurseryProvision.belongsTo(models.User, {
+        foreignKey: 'createdById',
+        as: 'createdByUser'
+      })
+
+      SchoolNurseryProvision.belongsTo(models.User, {
+        foreignKey: 'updatedById',
+        as: 'updatedByUser'
+      })
+    }
+  }
+
+  SchoolNurseryProvision.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      code:  {
+        type: DataTypes.STRING
+      },
+      name:  {
+        type: DataTypes.STRING
+      },
+      rank:  {
+        type: DataTypes.TINYINT
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at'
+      },
+      createdById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'created_by_id'
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'updated_at'
+      },
+      updatedById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
+      }
+    },
+    {
+      sequelize,
+      modelName: 'SchoolNurseryProvision',
+      tableName: 'school_nursery_provisions',
+      timestamps: true
+    }
+  )
+
+  // const createRevisionHook = require('../hooks/revisionHook')
+
+  // SchoolNurseryProvision.addHook('afterCreate', (instance, options) =>
+  //   createRevisionHook({ revisionModelName: 'SchoolNurseryProvisionRevision', modelKey: 'schoolNurseryProvision' })(instance, {
+  //     ...options,
+  //     hookName: 'afterCreate'
+  //   })
+  // )
+
+  // SchoolNurseryProvision.addHook('afterUpdate', (instance, options) => {
+  //   const hookName = instance.deletedById !== null ? 'afterDestroy' : 'afterUpdate'
+  //   createRevisionHook({ revisionModelName: 'SchoolNurseryProvisionRevision', modelKey: 'schoolNurseryProvision' })(instance, {
+  //     ...options,
+  //     hookName
+  //   })
+  // })
+
+  return SchoolNurseryProvision
+}

--- a/app/models/schoolReligiousCharacter.js
+++ b/app/models/schoolReligiousCharacter.js
@@ -1,0 +1,96 @@
+const { Model, DataTypes } = require('sequelize')
+
+module.exports = (sequelize) => {
+  class SchoolReligiousCharacter extends Model {
+    static associate(models) {
+      SchoolReligiousCharacter.hasMany(models.SchoolDetail, {
+        foreignKey: 'religiousCharacterCode',
+        sourceKey: 'code',
+        as: 'schoolDetails'
+      })
+
+      SchoolReligiousCharacter.belongsTo(models.User, {
+        foreignKey: 'createdById',
+        as: 'createdByUser'
+      })
+
+      SchoolReligiousCharacter.belongsTo(models.User, {
+        foreignKey: 'updatedById',
+        as: 'updatedByUser'
+      })
+    }
+  }
+
+  SchoolReligiousCharacter.init(
+    {
+      id: {
+        type: DataTypes.UUID,
+        defaultValue: DataTypes.UUIDV4,
+        allowNull: false,
+        primaryKey: true
+      },
+      code:  {
+        type: DataTypes.STRING
+      },
+      name:  {
+        type: DataTypes.STRING
+      },
+      rank:  {
+        type: DataTypes.TINYINT
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'created_at'
+      },
+      createdById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'created_by_id'
+      },
+      updatedAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        field: 'updated_at'
+      },
+      updatedById: {
+        type: DataTypes.UUID,
+        allowNull: false,
+        field: 'updated_by_id'
+      },
+      deletedAt: {
+        type: DataTypes.DATE,
+        field: 'deleted_at'
+      },
+      deletedById: {
+        type: DataTypes.UUID,
+        field: 'deleted_by_id'
+      }
+    },
+    {
+      sequelize,
+      modelName: 'SchoolReligiousCharacter',
+      tableName: 'school_religious_characters',
+      timestamps: true
+    }
+  )
+
+  // const createRevisionHook = require('../hooks/revisionHook')
+
+  // SchoolReligiousCharacter.addHook('afterCreate', (instance, options) =>
+  //   createRevisionHook({ revisionModelName: 'SchoolReligiousCharacterRevision', modelKey: 'schoolReligiousCharacter' })(instance, {
+  //     ...options,
+  //     hookName: 'afterCreate'
+  //   })
+  // )
+
+  // SchoolReligiousCharacter.addHook('afterUpdate', (instance, options) => {
+  //   const hookName = instance.deletedById !== null ? 'afterDestroy' : 'afterUpdate'
+  //   createRevisionHook({ revisionModelName: 'SchoolReligiousCharacterRevision', modelKey: 'schoolReligiousCharacter' })(instance, {
+  //     ...options,
+  //     hookName
+  //   })
+  // })
+
+  return SchoolReligiousCharacter
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -73,6 +73,8 @@ router.get('/placement-schools/remove-all-filters', checkIsAuthenticated, placem
 
 router.get('/placement-schools/remove-keyword-search', checkIsAuthenticated, placementSchoolController.removeKeywordSearch)
 
+router.get('/placement-schools/:schoolId/partnerships', checkIsAuthenticated, placementSchoolController.placementSchoolPartnerships)
+
 router.get('/placement-schools/:schoolId', checkIsAuthenticated, placementSchoolController.placementSchoolDetails)
 
 router.get('/placement-schools', checkIsAuthenticated, placementSchoolController.placementSchoolsList)

--- a/app/routes.js
+++ b/app/routes.js
@@ -39,7 +39,7 @@ const checkIsAuthenticated = (req, res, next) => {
   // the signed in user
   req.session.passport = passport
   // the base URL for navigation
-  res.locals.baseUrl = ''
+  res.locals.baseUrl = `/placement-schools/${req.params.schoolId}`
   next()
 }
 
@@ -72,6 +72,8 @@ router.get('/placement-schools/remove-school-education-phase-filter/:schoolEduca
 router.get('/placement-schools/remove-all-filters', checkIsAuthenticated, placementSchoolController.removeAllFilters)
 
 router.get('/placement-schools/remove-keyword-search', checkIsAuthenticated, placementSchoolController.removeKeywordSearch)
+
+router.get('/placement-schools/:schoolId', checkIsAuthenticated, placementSchoolController.placementSchoolDetails)
 
 router.get('/placement-schools', checkIsAuthenticated, placementSchoolController.placementSchoolsList)
 

--- a/app/seeders/20250721111400-seed-school-details.js
+++ b/app/seeders/20250721111400-seed-school-details.js
@@ -43,7 +43,7 @@ module.exports = {
           statutory_high_age: nullIfEmpty(school.statutory_high_age),
           boarders_code: nullIfEmpty(school.boarders_code),
           nursery_provision_code: nullIfEmpty(school.nursery_provision_code),
-          official_six_form_code: nullIfEmpty(school.official_six_form_code),
+          official_sixth_form_code: nullIfEmpty(school.official_six_form_code),
           gender_code: nullIfEmpty(school.gender_code),
           religious_character_code: nullIfEmpty(school.religious_character_code),
           admissions_policy_code: nullIfEmpty(school.admissions_policy_code),

--- a/app/seeders/20250721111400-seed-school-details.js
+++ b/app/seeders/20250721111400-seed-school-details.js
@@ -41,7 +41,7 @@ module.exports = {
           local_authority_code: nullIfEmpty(school.local_authority_code),
           statutory_low_age: nullIfEmpty(school.statutory_low_age),
           statutory_high_age: nullIfEmpty(school.statutory_high_age),
-          boarders_code: nullIfEmpty(school.boarders_code),
+          boarder_code: nullIfEmpty(school.boarders_code),
           nursery_provision_code: nullIfEmpty(school.nursery_provision_code),
           official_sixth_form_code: nullIfEmpty(school.official_six_form_code),
           gender_code: nullIfEmpty(school.gender_code),

--- a/app/seeders/20250721123400-seed-school-nursery-provisions.js
+++ b/app/seeders/20250721123400-seed-school-nursery-provisions.js
@@ -9,7 +9,7 @@ module.exports = {
     const transaction = await queryInterface.sequelize.transaction()
 
     try {
-      await queryInterface.bulkDelete('school_nursery_provision', null, { transaction })
+      await queryInterface.bulkDelete('school_nursery_provisions', null, { transaction })
       // await queryInterface.bulkDelete('school_nursery_provision_revisions', null, { transaction })
       // await queryInterface.bulkDelete('activity_logs', {
       //   entity_type: 'school_nursery_provision'
@@ -33,7 +33,7 @@ module.exports = {
         }
 
         // 1. Insert into users table
-        await queryInterface.bulkInsert('school_nursery_provision', [baseFields], { transaction })
+        await queryInterface.bulkInsert('school_nursery_provisions', [baseFields], { transaction })
 
         // 2. Create revision
         // const { id: _, ...revisionDataWithoutId } = baseFields
@@ -73,6 +73,6 @@ module.exports = {
     //   entity_type: 'school_nursery_provision'
     // })
     // await queryInterface.bulkDelete('school_nursery_provision_revisions', null, {})
-    await queryInterface.bulkDelete('school_nursery_provision', null, {})
+    await queryInterface.bulkDelete('school_nursery_provisions', null, {})
   }
 }

--- a/app/seeders/20250721123600-seed-school-sixth-forms.js
+++ b/app/seeders/20250721123600-seed-school-sixth-forms.js
@@ -9,7 +9,7 @@ module.exports = {
     const transaction = await queryInterface.sequelize.transaction()
 
     try {
-      await queryInterface.bulkDelete('school_sixth_form', null, { transaction })
+      await queryInterface.bulkDelete('school_sixth_forms', null, { transaction })
       // await queryInterface.bulkDelete('school_sixth_form_revisions', null, { transaction })
       // await queryInterface.bulkDelete('activity_logs', {
       //   entity_type: 'school_sixth_form'
@@ -33,7 +33,7 @@ module.exports = {
         }
 
         // 1. Insert into users table
-        await queryInterface.bulkInsert('school_sixth_form', [baseFields], { transaction })
+        await queryInterface.bulkInsert('school_sixth_forms', [baseFields], { transaction })
 
         // 2. Create revision
         // const { id: _, ...revisionDataWithoutId } = baseFields
@@ -73,6 +73,6 @@ module.exports = {
     //   entity_type: 'school_sixth_form'
     // })
     // await queryInterface.bulkDelete('school_sixth_form_revisions', null, {})
-    await queryInterface.bulkDelete('school_sixth_form', null, {})
+    await queryInterface.bulkDelete('school_sixth_forms', null, {})
   }
 }

--- a/app/views/_components/index.scss
+++ b/app/views/_components/index.scss
@@ -1,3 +1,4 @@
 @import "checkbox-filter/checkbox-filter";
 @import "filter/filter";
 @import "search/search";
+@import "secondary-navigation/secondary-navigation";

--- a/app/views/_components/secondary-navigation/_secondary-navigation.scss
+++ b/app/views/_components/secondary-navigation/_secondary-navigation.scss
@@ -1,0 +1,138 @@
+$app-secondary-navigation-active-link-border-width: govuk-spacing(1);
+$app-secondary-navigation-background: $govuk-canvas-background-colour;
+$app-secondary-navigation-border-colour: $govuk-border-colour;
+
+// We make the link colour a little darker than normal here so that it has
+// better perceptual contrast with the navigation background.
+$app-secondary-navigation-link-colour: govuk-shade($govuk-link-colour, 10%);
+
+.app-secondary-navigation {
+  margin-bottom: govuk-spacing(7);
+  border-bottom: 1px solid $app-secondary-navigation-border-colour;
+  // background-color: $app-secondary-navigation-background;
+}
+
+.app-secondary-navigation__container {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+
+  @include govuk-media-query($from: tablet) {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+}
+
+.app-secondary-navigation__item {
+  position: relative;
+  margin: govuk-spacing(2) 0;
+  border: 0 solid $app-secondary-navigation-link-colour;
+
+  @include govuk-media-query($from: tablet) {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding: govuk-spacing(4) 0;
+
+    &:not(:last-child) {
+      @include govuk-responsive-margin(6, $direction: right);
+    }
+  }
+}
+
+.app-secondary-navigation__item--active {
+  @include govuk-media-query($until: tablet) {
+    // Negative offset the left margin so we can place a current page indicator
+    // to the left without misaligning the list item text.
+    margin-left: ((govuk-spacing(2) + $app-secondary-navigation-active-link-border-width) * -1);
+    padding-left: govuk-spacing(2);
+    border-left-width: $app-secondary-navigation-active-link-border-width;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    padding-bottom: govuk-spacing(4) - $app-secondary-navigation-active-link-border-width;
+    border-bottom-width: $app-secondary-navigation-active-link-border-width;
+  }
+}
+
+.app-secondary-navigation__link {
+  @include govuk-link-common;
+  @include govuk-link-style-no-underline;
+  @include govuk-link-style-no-visited-state;
+
+  &:not(:hover):not(:focus) {
+    // We set the colour here as we don't want to override the hover or
+    // focus colours
+    color: $app-secondary-navigation-link-colour;
+  }
+}
+
+.app-secondary-navigation__toggle {
+  @include govuk-font($size: 19, $weight: bold);
+  display: inline-flex;
+  margin: govuk-spacing(2) 0;
+  padding: 0;
+  border: 0;
+  color: $app-secondary-navigation-link-colour;
+  background: none;
+  word-break: break-all;
+  cursor: pointer;
+  align-items: center;
+
+  &:focus {
+    @include govuk-focused-text;
+  }
+
+  &::after {
+    @include govuk-shape-arrow($direction: down, $base: 10px, $display: inline-block);
+    content: "";
+    margin-left: govuk-spacing(1);
+  }
+
+  &[aria-expanded="true"]::after {
+    @include govuk-shape-arrow($direction: up, $base: 10px, $display: inline-block);
+  }
+
+  // Ensure the button stays hidden if the hidden attribute is present
+  &[hidden] {
+    display: none;
+  }
+}
+
+.app-secondary-navigation__list {
+  @include govuk-font($size: 19);
+  margin: 0;
+  margin-bottom: govuk-spacing(3);
+  padding: 0;
+  list-style: none;
+
+  // Make the navigation list a flexbox. Doing so resolves a couple of
+  // accessibility problems caused by the list items being inline-blocks:
+  // - Removes the extra whitespace from between each list item that screen
+  //   readers would pointlessly announce.
+  // - Fixes an NVDA issue in Firefox and Chrome <= 124 where it would read
+  //   all of the links as a run-on sentence.
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-wrap: wrap;
+    margin-bottom: 0;
+
+    // However... IE11 totally trips over flexbox and doesn't wrap anything,
+    // making all of the items into a single, horizontally scrolling row,
+    // which is no good. This CSS hack removes the flexbox definition for
+    // IE 10 & 11, reverting it to the flawed, but OK, non-flexbox version.
+    //
+    // CSS hack taken from https://stackoverflow.com/questions/11173106/apply-style-only-on-ie#answer-36448860
+    // which also includes an explanation of why this works
+    @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+      display: block;
+    }
+  }
+}
+
+// This is a <strong> element that is used as a fallback mechanism for
+// visually indicating the current page in scenarios where CSS isn't
+// available. We don't actually want it to be bold normally, so set it to
+// inherit the parent font-weight.
+.app-secondary-navigation__active-fallback {
+  font-weight: inherit;
+}

--- a/app/views/_components/secondary-navigation/macro.njk
+++ b/app/views/_components/secondary-navigation/macro.njk
@@ -1,0 +1,3 @@
+{% macro appSecondaryNavigation(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/views/_components/secondary-navigation/template.njk
+++ b/app/views/_components/secondary-navigation/template.njk
@@ -1,0 +1,13 @@
+<nav class="app-secondary-navigation {{- ' ' + params.classes if params.classes}}" {%- if params.label %} aria-label="{{ params.label }}"{% endif %} {%- for attribute, value in params.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
+  <ul class="app-secondary-navigation__list">
+    {%- for item in params.items %}
+      {% if item.html.length or item.text.length %}
+        <li class="app-secondary-navigation__item {{- ' app-secondary-navigation__item--active' if item.active }}">
+          <a class="app-secondary-navigation__link" {{ 'aria-current="page"' | safe if item.active }} href="{{ item.href }}" {%- for attribute, value in item.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
+            {{- item.html | safe if item.html else item.text -}}
+          </a>
+        </li>
+      {% endif %}
+    {% endfor -%}
+  </ul>
+</nav>

--- a/app/views/layouts/auth.njk
+++ b/app/views/layouts/auth.njk
@@ -16,19 +16,7 @@
   {{ govukHeader({
     rebrand: true,
     homepageUrl: "/",
-    containerClasses: "govuk-width-container",
-    navigationClasses: "govuk-header__navigation--end",
-    navigation: [
-      {
-        href: "/account",
-        text: "Your account",
-        active: headerNavId == "account"
-      },
-      {
-        href: "/sign-out",
-        text: "Sign out"
-      }
-    ] if not hideAccountNavigation
+    containerClasses: "govuk-width-container"
   }) }}
 
   {{ govukServiceNavigation({

--- a/app/views/layouts/main.njk
+++ b/app/views/layouts/main.njk
@@ -4,6 +4,7 @@
 
 {% from "_components/checkbox-filter/macro.njk" import appCheckboxFilter %}
 {% from "_components/search/macro.njk" import appSearch %}
+{% from "_components/secondary-navigation/macro.njk" import appSecondaryNavigation %}
 
 {% block pageTitle -%}
   {{ subtitle + " - " if subtitle }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
@@ -17,20 +18,17 @@
   {{ govukHeader({
     rebrand: true,
     homepageUrl: "/",
-    containerClasses: "govuk-width-container",
-    navigationClasses: "govuk-header__navigation--end",
-    navigation: [
-      {
-        href: "/account",
-        text: "Your account",
-        active: headerNavId == "account"
-      },
-      {
-        href: "/sign-out",
-        text: "Sign out"
-      }
-    ]
+    containerClasses: "govuk-width-container"
   }) }}
+
+  {% set navigationEndHtml %}
+    <li class="govuk-service-navigation__item app-service-navigation__align-right">
+      <a class="govuk-service-navigation__link" href="/account" {{- ' aria-current="true"' if primaryNavId == "account" }}>Your account</a>
+    </li>
+    <li class="govuk-service-navigation__item">
+      <a class="govuk-service-navigation__link" href="/sign-out">Sign out</a>
+    </li>
+  {% endset %}
 
   {{ govukServiceNavigation({
     navigationId: "primaryNavigation",
@@ -52,7 +50,10 @@
         href: "/activity",
         active: primaryNavId == "activity"
       } if 1==0
-    ]
+    ],
+    slots: {
+      navigationEnd: navigationEndHtml
+    }
   }) }}
 
   {% include "_includes/phase-banner.njk" %}

--- a/app/views/placement-schools/_secondary-navigation.njk
+++ b/app/views/placement-schools/_secondary-navigation.njk
@@ -1,0 +1,20 @@
+{{ appSecondaryNavigation({
+  label: "Placement school navigation",
+  items: [
+    {
+      href: baseUrl,
+      text: "School details",
+      active: secondaryNavId == "details"
+    },
+    {
+      href: baseUrl + "/partnerships",
+      text: "Partnerships",
+      active: secondaryNavId == "partnerships"
+    },
+    {
+      href: baseUrl + "/activity",
+      text: "Activity log",
+      active: secondaryNavId == "activity"
+    } if 1==0
+  ]
+}) }}

--- a/app/views/placement-schools/index.njk
+++ b/app/views/placement-schools/index.njk
@@ -39,9 +39,9 @@
       {% for school in placementSchools %}
 
         {% set nameHtml %}
-          {# <a href="{{ actions.view }}/{{ school.id }}" class="govuk-link"> #}
+          <a href="{{ actions.view }}/{{ school.id }}" class="govuk-link">
             {{ school.name }}
-          {# </a> #}
+          </a>
         {% endset %}
 
         {% set schoolTypeGroupHtml %}

--- a/app/views/placement-schools/partnerships/index.njk
+++ b/app/views/placement-schools/partnerships/index.njk
@@ -1,0 +1,60 @@
+{% extends "layouts/main.njk" %}
+
+{% set primaryNavId = "placementSchools" %}
+{% set secondaryNavId = "partnerships" %}
+
+{% set title = placementSchool.name %}
+{% set caption = "Placement school" %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: "/placement-schools"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+{% include "_includes/notification-banner.njk" %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {% include "_includes/page-heading.njk" %}
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    {% include "../_secondary-navigation.njk" %}
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h2 class="govuk-heading-m">Partnerships</h2>
+
+    {% if groupedPartnerships.length %}
+      <ul class="govuk-list govuk-list--spaced">
+        {% for year in groupedPartnerships %}
+          <li>
+            <strong>{{ year.name }}</strong>
+            <ul class="govuk-list govuk-list--bullet">
+              {% for provider in year.providers %}
+                <li>{{ provider.name }}</li>
+              {% endfor %}
+            </ul>
+          </li>
+        {% endfor %}
+      </ul>
+
+    {% else %}
+      <p class="govuk-body">There are no partnerships for {{ placementSchool.name if placementSchool.name else "this school" }}.</p>
+    {% endif %}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/placement-schools/show.njk
+++ b/app/views/placement-schools/show.njk
@@ -1,0 +1,132 @@
+{% extends "layouts/main.njk" %}
+
+{% set primaryNavId = "placementSchools" %}
+{% set secondaryNavId = "details" %}
+
+{% set title = placementSchool.name %}
+{% set caption = "Placement school" %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+  text: "Back",
+  href: "/placement-schools"
+}) }}
+{% endblock %}
+
+{% block content %}
+
+{% include "_includes/notification-banner.njk" %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    {% include "_includes/page-heading.njk" %}
+
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    {% include "./_secondary-navigation.njk" %}
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h2 class="govuk-heading-m">School details</h2>
+
+    {% set schoolTypeGroupHtml %}
+      <ul class="govuk-list">
+        <li>
+          {{ placementSchool.schoolGroup.name }}
+        </li>
+        <li class="govuk-!-font-size-16">
+          {{ placementSchool.schoolType.name }}
+        </li>
+      </ul>
+    {% endset %}
+
+    {% set addressHtml %}
+      {% if placementSchool.schoolAddress.line1.length %}
+        {{ placementSchool.schoolAddress.line1 }}<br>
+      {% endif %}
+      {% if placementSchool.schoolAddress.line2.length %}
+        {{ placementSchool.schoolAddress.line2 }}<br>
+      {% endif %}
+      {% if placementSchool.schoolAddress.line3.length %}
+        {{ placementSchool.schoolAddress.line3 }}<br>
+      {% endif %}
+      {% if placementSchool.schoolAddress.town.length %}
+        {{ placementSchool.schoolAddress.town }}<br>
+      {% endif %}
+      {% if placementSchool.schoolAddress.county.length %}
+        {{ placementSchool.schoolAddress.county }}<br>
+      {% endif %}
+      {% if placementSchool.schoolAddress.postcode.length %}
+        {{ placementSchool.schoolAddress.postcode }}<br>
+      {% endif %}
+    {% endset %}
+
+    {{ govukSummaryList({
+      rows: [
+        {
+          key: {
+            text: "UK provider reference number (UKPRN)"
+          },
+          value: {
+            text: placementSchool.ukprn if placementSchool.ukprn.length else "Not known",
+            classes: "govuk-hint" if not placementSchool.ukprn.length
+          }
+        },
+        {
+          key: {
+            text: "Unique reference number (URN)"
+          },
+          value: {
+            text: placementSchool.urn if placementSchool.urn.length else "Not known",
+            classes: "govuk-hint" if not placementSchool.urn.length
+          }
+        },
+        {
+          key: {
+            text: "School type"
+          },
+          value: {
+            html: schoolTypeGroupHtml
+          }
+        },
+        {
+          key: {
+            text: "Education phase"
+          },
+          value: {
+            text: placementSchool.schoolEducationPhase.name if placementSchool.schoolEducationPhase.name.length else "Not known",
+            classes: "govuk-hint" if not placementSchool.schoolEducationPhase.name.length
+          }
+        },
+        {
+          key: {
+            text: "School status"
+          },
+          value: {
+            text: placementSchool.schoolStatus.name if placementSchool.schoolStatus.name.length else "Not known",
+            classes: "govuk-hint" if not placementSchool.schoolStatus.name.length
+          }
+        },
+        {
+          key: {
+            text: "Address"
+          },
+          value: {
+            html: addressHtml if addressHtml.length else "Not known",
+            classes: "govuk-hint" if not addressHtml.length
+          }
+        }
+      ]
+    }) }}
+
+  </div>
+</div>
+
+{% endblock %}


### PR DESCRIPTION
This PR implements viewing a placement school.

For a given placement school, I split the interface up using secondary navigation. The two navigation options are:

- School details
- Partnerships

In the school details section, we show:

- school's details (for example, URN, UKPRN, status, type, education phase) - the same as we show on the list page
- school address

Note: We currently do not display a school's extended details, also known as contrast factors (for example, gender, religious affiliation, urban/rural status, size, etc.). We can add this detail in a separate PR.

In the schools' partnerships section, we display providers organised by academic year, with the most recent academic year listed first.

