### PR TITLE
Add error pages

### DIFF
--- a/app/controllers/error.js
+++ b/app/controllers/error.js
@@ -1,0 +1,23 @@
+exports.pageNotFound = (req, res) => {
+  res.render('../views/errors/404')
+}
+
+exports.unexpectedError = (req, res) => {
+  res.render('../views/errors/500')
+}
+
+exports.serviceUnavailable = (req, res) => {
+  res.render('../views/errors/503')
+}
+
+exports.unauthorised = (req, res) => {
+  res.render('../views/errors/unauthorised')
+}
+
+exports.accountNotRecognised = (req, res) => {
+  res.render('../views/errors/account-not-recognised')
+}
+
+exports.accountNoOrganisation = (req, res) => {
+  res.render('../views/errors/account-no-organisation')
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -29,6 +29,7 @@ const passport = {
 /// Controller modules
 /// ------------------------------------------------------------------------ ///
 const contentController = require('./controllers/content')
+const errorController = require('./controllers/error')
 const feedbackController = require('./controllers/feedback')
 const searchController = require('./controllers/search')
 const supportAccountController = require('./controllers/support/account')
@@ -148,16 +149,6 @@ router.post('/feedback/check', feedbackController.newFeedbackCheck_post)
 router.get('/feedback/confirmation', feedbackController.newFeedbackConfirmation_get)
 
 /// ------------------------------------------------------------------------ ///
-/// AUTOCOMPLETE ROUTES
-/// ------------------------------------------------------------------------ ///
-
-router.get('/location-suggestions', searchController.locationSuggestions_json)
-
-router.get('/provider-suggestions', searchController.providerSuggestions_json)
-
-router.get('/school-suggestions', searchController.schoolSuggestions_json)
-
-/// ------------------------------------------------------------------------ ///
 /// GENERAL ROUTES
 /// ------------------------------------------------------------------------ ///
 
@@ -166,6 +157,32 @@ router.get('/accessibility', contentController.accessibility)
 router.get('/cookies', contentController.cookies)
 
 router.get('/privacy', contentController.privacy)
+
+router.get('/404', checkIsAuthenticated, errorController.pageNotFound)
+router.get('/page-not-found', checkIsAuthenticated, errorController.pageNotFound)
+
+router.get('/500', errorController.unexpectedError)
+router.get('/server-error', errorController.unexpectedError)
+
+router.get('/503', errorController.serviceUnavailable)
+router.get('/service-unavailable', errorController.serviceUnavailable)
+
+router.get('/unauthorised', errorController.unauthorised)
+router.get('/account-not-authorised', errorController.unauthorised)
+
+router.get('/account-not-recognised', errorController.accountNotRecognised)
+
+router.get('/account-no-organisation', errorController.accountNoOrganisation)
+
+/// ------------------------------------------------------------------------ ///
+/// AUTOCOMPLETE ROUTES
+/// ------------------------------------------------------------------------ ///
+
+router.get('/location-suggestions', searchController.locationSuggestions_json)
+
+router.get('/provider-suggestions', searchController.providerSuggestions_json)
+
+router.get('/school-suggestions', searchController.schoolSuggestions_json)
 
 /// ------------------------------------------------------------------------ ///
 ///

--- a/app/views/errors/404.njk
+++ b/app/views/errors/404.njk
@@ -1,0 +1,14 @@
+{% extends "layouts/main.njk" %}
+
+{% set title = "Page not found" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">If you typed a web address, check it is correct.</p>
+      <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/500.njk
+++ b/app/views/errors/500.njk
@@ -1,0 +1,17 @@
+{% extends "layouts/error.njk" %}
+
+{% set hidePhaseBanner = true %}
+{% set hideFooterLinks = true %}
+
+{% set title = "Sorry, there’s a problem with the service" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">Try again later.</p>
+      <p class="govuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
+      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/503.njk
+++ b/app/views/errors/503.njk
@@ -1,0 +1,17 @@
+{% extends "layouts/error.njk" %}
+
+{% set hidePhaseBanner = true %}
+{% set hideFooterLinks = true %}
+
+{% set title = "Sorry, the service is unavailable" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">You will be able to use the service from 3pm on Tuesday, 26 August 2025.</p>
+      <p class="govuk-body">If you reached this page after submitting information then it has not been saved. You will need to enter it again when the service is available.</p>
+      <p class="govuk-body">If you have any questions, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/account-no-organisation.njk
+++ b/app/views/errors/account-no-organisation.njk
@@ -1,0 +1,25 @@
+{% extends "layouts/error.njk" %}
+
+{% set hidePrimaryNavigation = true %}
+
+{% set title = "You have not been linked to an organisation yet" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">You’ve successfully signed in to {{ serviceName }}, but your account has not been linked to an organisation yet.</p>
+      <p class="govuk-body">Your account needs to be linked to an organisation so you can use {{ serviceName }}.</p>
+      <p class="govuk-body">To be added to an organisation, email us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+      <p class="govuk-body">In your email tell us:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          the email address associated with your {{ serviceName }} account
+        </li>
+        <li>
+          which organisation you’d like to be added to
+        </li>
+      </ul>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/account-not-recognised.njk
+++ b/app/views/errors/account-not-recognised.njk
@@ -1,0 +1,15 @@
+{% extends "layouts/error.njk" %}
+
+{% set hidePrimaryNavigation = true %}
+
+{% set title = "Ask for an account to access the " + serviceName %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">Although you have a DfE Sign-in account, you also need an account to access the {{ serviceName }}.</p>
+      <p class="govuk-body">If you think you should have an account, email us at <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/errors/unauthorised.njk
+++ b/app/views/errors/unauthorised.njk
@@ -1,0 +1,15 @@
+{% extends "layouts/error.njk" %}
+
+{% set hidePrimaryNavigation = true %}
+
+{% set title = "Your account is not authorised" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ title }}</h1>
+      <p class="govuk-body">You are seeing this page because you have signed into {{ serviceName }} but your account is not authorised to view this page.</p>
+      <p class="govuk-body">If you think your account should be authorised, email <a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/layouts/error.njk
+++ b/app/views/layouts/error.njk
@@ -1,0 +1,26 @@
+{% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
+
+{% set govukRebrand = true %}
+
+{% block pageTitle -%}
+  {{ subtitle + " - " if subtitle }}{{ title + " - " if title }}{{ caption + " - " if caption }}{{ serviceName }} - GOV.UK
+{%- endblock %}
+
+{% block head %}
+  {% include "_includes/head.njk" %}
+{% endblock %}
+
+{% block header %}
+  {{ govukHeader({
+    rebrand: true,
+    homepageUrl: "/"
+  }) }}
+
+  {% if not hidePhaseBanner %}
+    {% include "_includes/phase-banner.njk" %}
+  {% endif %}
+{% endblock %}
+
+{% block footer %}
+  {% include "_includes/footer.njk" %}
+{% endblock %}


### PR DESCRIPTION
This PR adds standard error pages for:

- page not found (404)
- server error (500)
- service unavailable (503)
- account not authorised
- account not recognised
- no organisation linked to the account

Note: The prototype doesn't implement the pages. For example, if a 404 error occurs, we use the GOV.UK prototype kit error page rather than the RoPS equivalent.

View deployment: https://register-schools-pr-20.herokuapp.com/