### PR TITLE
Tidy up filter search results code

### DIFF
--- a/app/helpers/search.js
+++ b/app/helpers/search.js
@@ -1,3 +1,16 @@
+const {
+  getRegionOptions,
+  getRegionLabel,
+  getSchoolTypeOptions,
+  getSchoolTypeLabel,
+  getSchoolGroupOptions,
+  getSchoolGroupLabel,
+  getSchoolStatusOptions,
+  getSchoolStatusLabel,
+  getSchoolEducationPhaseOptions,
+  getSchoolEducationPhaseLabel
+} = require('./gias')
+
 const getCheckboxValues = (name, data) => {
   return name && (Array.isArray(name)
     ? name
@@ -45,9 +58,195 @@ const getRadiusLabel = async (code) => {
   return row?.name || `Unknown (${code})`
 }
 
+const asInt = (v, fallback) => {
+  const n = parseInt(v, 10)
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}
+
+// --- selected filters (UI) builder ------------------------------------------
+
+/**
+ * Build the selected filters structure from a config + selected values.
+ * @param {Array<{
+ *   key: string,
+ *   heading: string,
+ *   selected: string[]|undefined,
+ *   labelGetter: (code: string) => Promise<string>,
+ *   removeHref: (code: string) => string
+ * }>} groups
+ */
+const buildSelectedFilters = async (groups) => {
+  const categories = []
+
+  for (const g of groups) {
+    if (!g.selected?.length) continue
+    const items = await Promise.all(
+      g.selected.map(async (code) => ({
+        text: await g.labelGetter(code),
+        href: g.removeHref(code)
+      }))
+    )
+    categories.push({ heading: { text: g.heading }, items })
+  }
+
+  return categories.length ? { categories } : null
+}
+
+// --- filter parsing ----------------------------------------------------------
+
+/**
+ * From req.session.data.filters, normalise to arrays we can pass to queries
+ * without throwing if keys are missing. Leaves “radius” as string (single).
+ * @param {*} filters
+ */
+const parseFilters = (filters = {}) => ({
+  // location mode
+  radius: filters.radius ?? null,
+  schoolType: Array.isArray(filters.schoolType) ? filters.schoolType : (filters.schoolType ? [filters.schoolType] : []),
+  schoolGroup: Array.isArray(filters.schoolGroup) ? filters.schoolGroup : (filters.schoolGroup ? [filters.schoolGroup] : []),
+  schoolStatus: Array.isArray(filters.schoolStatus) ? filters.schoolStatus : (filters.schoolStatus ? [filters.schoolStatus] : []),
+  schoolEducationPhase: Array.isArray(filters.schoolEducationPhase) ? filters.schoolEducationPhase : (filters.schoolEducationPhase ? [filters.schoolEducationPhase] : []),
+
+  // provider mode
+  region: Array.isArray(filters.region) ? filters.region : (filters.region ? [filters.region] : [])
+})
+
+/**
+ * True if any filter arrays have content (or radius provided).
+ */
+const hasAnyFilters = (f, keys) =>
+  keys.some((k) => Array.isArray(f[k]) ? f[k].length > 0 : Boolean(f[k]))
+
+// --- option lists fetcher ----------------------------------------------------
+
+const fetchFilterOptions = async (mode) => {
+  // shared
+  const [
+    filterSchoolTypeItems,
+    filterSchoolGroupItems,
+    filterSchoolStatusItems,
+    filterSchoolEducationPhaseItems
+  ] = await Promise.all([
+    getSchoolTypeOptions(),
+    getSchoolGroupOptions(),
+    getSchoolStatusOptions(),
+    getSchoolEducationPhaseOptions()
+  ])
+
+  if (mode === 'location') {
+    const filterRadiusItems = await getRadiusOptions()
+    return {
+      filterRadiusItems,
+      filterSchoolTypeItems,
+      filterSchoolGroupItems,
+      filterSchoolStatusItems,
+      filterSchoolEducationPhaseItems
+    }
+  }
+
+  if (mode === 'provider') {
+    const filterRegionItems = await getRegionOptions()
+    return {
+      filterRegionItems,
+      filterSchoolTypeItems,
+      filterSchoolGroupItems,
+      filterSchoolStatusItems,
+      filterSchoolEducationPhaseItems
+    }
+  }
+
+  return {}
+}
+
+// --- per-mode configs for selected-filters UI --------------------------------
+
+const locationSelectedFilterConfig = (sel) => ([
+  // If you re-enable radius chips, uncomment this block
+  // {
+  //   key: 'radius',
+  //   heading: 'Search radius',
+  //   selected: sel.radius ? [sel.radius] : [],
+  //   labelGetter: getRadiusLabel,
+  //   removeHref: (code) => `/results/remove-radius-filter/${code}`
+  // },
+  {
+    key: 'schoolGroup',
+    heading: 'School group',
+    selected: sel.schoolGroup,
+    labelGetter: getSchoolGroupLabel,
+    removeHref: (code) => `/results/remove-school-group-filter/${code}`
+  },
+  {
+    key: 'schoolType',
+    heading: 'School type',
+    selected: sel.schoolType,
+    labelGetter: getSchoolTypeLabel,
+    removeHref: (code) => `/results/remove-school-type-filter/${code}`
+  },
+  {
+    key: 'schoolEducationPhase',
+    heading: 'School education phase',
+    selected: sel.schoolEducationPhase,
+    labelGetter: getSchoolEducationPhaseLabel,
+    removeHref: (code) => `/results/remove-school-education-phase-filter/${code}`
+  },
+  {
+    key: 'schoolStatus',
+    heading: 'School status',
+    selected: sel.schoolStatus,
+    labelGetter: getSchoolStatusLabel,
+    removeHref: (code) => `/results/remove-school-status-filter/${code}`
+  }
+])
+
+const providerSelectedFilterConfig = (sel) => ([
+  {
+    key: 'region',
+    heading: 'Region',
+    selected: sel.region,
+    labelGetter: getRegionLabel,
+    removeHref: (code) => `/results/remove-region-filter/${code}`
+  },
+  {
+    key: 'schoolGroup',
+    heading: 'School group',
+    selected: sel.schoolGroup,
+    labelGetter: getSchoolGroupLabel,
+    removeHref: (code) => `/results/remove-school-group-filter/${code}`
+  },
+  {
+    key: 'schoolType',
+    heading: 'School type',
+    selected: sel.schoolType,
+    labelGetter: getSchoolTypeLabel,
+    removeHref: (code) => `/results/remove-school-type-filter/${code}`
+  },
+  {
+    key: 'schoolEducationPhase',
+    heading: 'School education phase',
+    selected: sel.schoolEducationPhase,
+    labelGetter: getSchoolEducationPhaseLabel,
+    removeHref: (code) => `/results/remove-school-education-phase-filter/${code}`
+  },
+  {
+    key: 'schoolStatus',
+    heading: 'School status',
+    selected: sel.schoolStatus,
+    labelGetter: getSchoolStatusLabel,
+    removeHref: (code) => `/results/remove-school-status-filter/${code}`
+  }
+])
+
 module.exports = {
   getCheckboxValues,
   removeFilter,
   getRadiusOptions,
-  getRadiusLabel
+  getRadiusLabel,
+  asInt,
+  buildSelectedFilters,
+  parseFilters,
+  hasAnyFilters,
+  fetchFilterOptions,
+  locationSelectedFilterConfig,
+  providerSelectedFilterConfig
 }

--- a/app/views/search/results-school.njk
+++ b/app/views/search/results-school.njk
@@ -12,14 +12,8 @@
     {% include "_includes/page-heading.njk" %}
 
     <p class="govuk-body">
-      <a class="govuk-link" href="{{ actions.search }}">Search again</a>
+      <a class="govuk-link" href="{{ actions.newSearch }}">Search again</a>
     </p>
-
-    {# <p class="govuk-body">
-      School search: {{data|dump|safe}}
-    </p>
-
-    {{placementSchool|dump|safe}} #}
 
     {% set urnHtml %}
       <ul class="govuk-list">


### PR DESCRIPTION
This PR includes:

- One way to read state: prefer `req.query` for progressive enhancement, fall back to `req.session.data` so it works with/without JS
- Consistent defaults: `asInt` guards page/limit; `parseFilters` normalises everything to arrays (except radius)
- DRY selected-filters UI: one generic `buildSelectedFilters()` + per-mode configs avoids repeating Promise.all blocks
- Single place for option lists: `fetchFilterOptions(mode)` centralises option fetching
- Clear “has filters” check: `hasAnyFilters()` takes a list of keys; easy to add/remove
- Safer location checks: validate `place.geometry.location` numbers explicitly
- Tidy early returns and redirects: bail out fast on missing prerequisites
- Error handling: wrap in try/catch and `next(err)` to use your app’s error page
- Commented radius chips: easy to re-enable later; logic remains wired up

View deployment: https://register-schools-pr-23.herokuapp.com/